### PR TITLE
meet-up vol.2の金額表記を正しいものに修正

### DIFF
--- a/website/app/(meetup2)/meetup2/main.tsx
+++ b/website/app/(meetup2)/meetup2/main.tsx
@@ -54,7 +54,7 @@ export const Main = () => {
           <br />
           2024年12月14日(土) 18:00〜
           <br />
-          参加費 3000円
+          参加費 2000円
           <br />
           <br />
           <div className="">


### PR DESCRIPTION
参加費 2000円 が正しい値なので修正

参考: https://docs.google.com/document/d/1GrBh5djVLqT5L8EWKHa0jdq8mbTKmmE-RjJGhl90_do/edit?tab=t.0